### PR TITLE
[Parser] Fix to work with Lightyear git-tip

### DIFF
--- a/Protobuf/ParseUtils.idr
+++ b/Protobuf/ParseUtils.idr
@@ -53,7 +53,7 @@ fieldFromFieldList {d=MkFieldDescriptor Required _ name _} xs = case (last' xs) 
 fieldFromFieldList {d=MkFieldDescriptor Repeated _ _ _} xs = Right xs
 
 export messageFromFieldList : FieldList fields -> Either String (InterpFields fields)
-messageFromFieldList {fields=Nil} _ = return Nil
+messageFromFieldList {fields=Nil} _ = pure Nil
 messageFromFieldList {fields=f::fs} xs = let (ys, zs) = reduceFieldList xs in
   case fieldFromFieldList ys of
     Left err => Left err

--- a/Protobuf/Parser.idr
+++ b/Protobuf/Parser.idr
@@ -29,6 +29,7 @@ import Lightyear
 import Lightyear.Char
 import Lightyear.Strings
 import Lightyear.Combinators
+import Lightyear.Position
 
 import Protobuf.Core
 
@@ -58,13 +59,13 @@ pushScope : String -> ProtoParser String
 pushScope name = do {
   (MkParserState scope messages enums) <- get
   put (MkParserState (scope ++ name ++ ".") messages enums)
-  return scope
+  pure scope
 }
 
 getScope : ProtoParser String
 getScope = do {
   (MkParserState scope messages enums) <- get
-  return scope
+  pure scope
 }
 
 setScope : String -> ProtoParser ()
@@ -75,12 +76,12 @@ setScope scope = do {
 
 
 requiredSpace : ProtoParser ()
-requiredSpace = space *> spaces *> return ()
+requiredSpace = space *> spaces *> pure ()
 
 label : ProtoParser Label
-label = (char 'o' >! string "ptional" *> requiredSpace *> return Optional)
-    <|> (string "req" >! string "uired" *> requiredSpace *> return Required)
-    <|> (string "rep" >! string "eated" *> requiredSpace *> return Repeated)
+label = (char 'o' >! string "ptional" *> requiredSpace *> pure Optional)
+    <|> (string "req" >! string "uired" *> requiredSpace *> pure Required)
+    <|> (string "rep" >! string "eated" *> requiredSpace *> pure Repeated)
     <?> "Label"
 
 isIdentifierChar : Char -> Bool
@@ -90,7 +91,7 @@ identifier : ProtoParser String
 identifier = (map pack (some (satisfy isIdentifierChar))) <* spaces
 
 nothingToErr : (errMsg : String) -> Maybe a -> ProtoParser a
-nothingToErr errMsg = maybe (fail errMsg) return
+nothingToErr errMsg = maybe (fail errMsg) pure
 
 nonNegative : ProtoParser Int
 nonNegative = do {
@@ -109,14 +110,14 @@ enumValueDescriptor = do {
   token "="
   number <- nonNegative
   token ";"
-  return (MkEnumValueDescriptor name number)
+  pure (MkEnumValueDescriptor name number)
 }
 
 enumDescriptor : ProtoParser ()
 enumDescriptor = (token "enum") *!> (do {
   name <- identifier
   values <- braces (many (enumValueDescriptor))
-  (k ** values') <- return (listToVect values)
+  (k ** values') <- pure (listToVect values)
   scope <- getScope
   addEnum (MkEnumDescriptor (scope ++ name) values')
 })
@@ -127,7 +128,7 @@ messageType = do {
   state <- get
   case (find (\x => name x == msgName) (messages state)) of
     Nothing => fail $ "A message type (no message named " ++ msgName ++ ")"
-    Just msg => return (PBMessage msg)
+    Just msg => pure (PBMessage msg)
 }
 
 enumType : ProtoParser FieldValueDescriptor
@@ -136,25 +137,25 @@ enumType = do {
   state <- get
   case (find (\x => name x == enumName) (enums state)) of
     Nothing => fail $ "An enum type (no enum named " ++ enumName ++ ")"
-    Just enum => return (PBEnum enum)
+    Just enum => pure (PBEnum enum)
 }
 
 fieldValueDescriptor : ProtoParser FieldValueDescriptor
-fieldValueDescriptor = (token "double" *!> return PBDouble)
-                    <|> (token "float" *!> return PBFloat)
-                    <|> (token "int32" *!> return PBInt32)
-                    <|> (token "int64" *!> return PBInt64)
-                    <|> (token "uint32" *!> return PBUInt32)
-                    <|> (token "uint64" *!> return PBUInt64)
-                    <|> (token "sint32" *!> return PBSInt32)
-                    <|> (token "sint64" *!> return PBSInt64)
-                    <|> (token "fixed32" *!> return PBFixed32)
-                    <|> (token "fixed64" *!> return PBFixed64)
-                    <|> (token "sfixed32" *!> return PBSFixed32)
-                    <|> (token "sfixed64" *!> return PBSFixed64)
-                    <|> (token "bool" *!> return PBBool)
-                    <|> (token "string" *!> return PBString)
-                    <|> (token "bytes" *!> return PBBytes)
+fieldValueDescriptor = (token "double" *!> pure PBDouble)
+                    <|> (token "float" *!> pure PBFloat)
+                    <|> (token "int32" *!> pure PBInt32)
+                    <|> (token "int64" *!> pure PBInt64)
+                    <|> (token "uint32" *!> pure PBUInt32)
+                    <|> (token "uint64" *!> pure PBUInt64)
+                    <|> (token "sint32" *!> pure PBSInt32)
+                    <|> (token "sint64" *!> pure PBSInt64)
+                    <|> (token "fixed32" *!> pure PBFixed32)
+                    <|> (token "fixed64" *!> pure PBFixed64)
+                    <|> (token "sfixed32" *!> pure PBSFixed32)
+                    <|> (token "sfixed64" *!> pure PBSFixed64)
+                    <|> (token "bool" *!> pure PBBool)
+                    <|> (token "string" *!> pure PBString)
+                    <|> (token "bytes" *!> pure PBBytes)
                     <|> messageType
                     <|> enumType
                     <?> "The name of a message, enum or primitive type"
@@ -167,7 +168,7 @@ fieldDescriptor = do {
   token "="
   number <- nonNegative
   token ";"
-  return (MkFieldDescriptor l ty name number)
+  pure (MkFieldDescriptor l ty name number)
 }
 
 messageDescriptor : ProtoParser ()
@@ -175,11 +176,11 @@ messageDescriptor = (token "message") *!> (do {
   name <- identifier
   scope <- pushScope name
   -- Parse fields and nested enum and message descriptors
-  fields <- braces (many ((fieldDescriptor >>= return . Just)
-                      <|> (messageDescriptor *> return Nothing)
-                      <|> (enumDescriptor *> return Nothing)))
+  fields <- braces (many ((fieldDescriptor >>= pure . Just)
+                      <|> (messageDescriptor *> pure Nothing)
+                      <|> (enumDescriptor *> pure Nothing)))
   setScope scope
-  (k ** fields') <- return (listToVect (mapMaybe (\x => x) fields))
+  (k ** fields') <- pure (listToVect (mapMaybe (\x => x) fields))
   addMessage (MkMessageDescriptor (scope ++ name) fields')
 })
 
@@ -187,13 +188,11 @@ fileDescriptor : ProtoParser ()
 fileDescriptor = (many (messageDescriptor <|> enumDescriptor)) *> eof
 
 runParser : String -> Either String ParserState
-runParser input = case output of
-    Success _ x => Right x
-    Failure es  => Left $ formatError input es
-  where output : Result String ParserState
-        output = evalState
-          (execParserT (spaces *> fileDescriptor *> get) input)
-          (MkParserState "" [] [])
+runParser input =
+    let st = execParserT (spaces *> fileDescriptor *> get) (initialState Nothing input 8) in
+        case runStateT st $ MkParserState "" [] [] of
+            Id (MkReply (ST str _ _) (Failure _), _) => Left str
+            Id (MkReply _ (Success _), es) => Right es
 
 export parseFile : String -> Either String (List MessageDescriptor, List EnumDescriptor)
 parseFile input = case runParser input of

--- a/Protobuf/Printer.idr
+++ b/Protobuf/Printer.idr
@@ -34,7 +34,7 @@ print s = do {
 getIndent : Printer Nat
 getIndent = do {
   (indent, buffer) <- get
-  return indent
+  pure indent
 }
 
 putIndent : Nat -> Printer ()

--- a/Protobuf/TextFormat.idr
+++ b/Protobuf/TextFormat.idr
@@ -34,7 +34,7 @@ mutual
     printFields fields
 
   printFields : InterpFields d -> Printer ()
-  printFields {d=Nil} Nil = return ()
+  printFields {d=Nil} Nil = pure ()
   printFields {d=f::fs} (x::xs) = do {
     printField x
     printFields xs
@@ -42,7 +42,7 @@ mutual
 
   printField : interpField d -> Printer ()
   printField {d=MkFieldDescriptor Optional _ name number} =
-    maybe (return ()) (printSingleFieldValue name)
+    maybe (pure ()) (printSingleFieldValue name)
   printField {d=MkFieldDescriptor Required _ name number} =
     (printSingleFieldValue name)
   printField {d=MkFieldDescriptor Repeated _ name number} =
@@ -96,7 +96,7 @@ parseString = do {
   chars <- many (satisfy (\c => c /= '"'))
   char '"'
   spaces
-  return (pack chars)
+  pure (pack chars)
 }
 
 parseInteger : Parser Integer
@@ -105,7 +105,7 @@ parseInteger = do {
   spaces
   case parseInteger (pack chars) of
     Nothing => fail $ "Could not parse " ++ (pack chars) ++ " as an integer"
-    Just x => return x
+    Just x => pure x
 }
 
 parseDouble : Parser Double
@@ -114,12 +114,12 @@ parseDouble = do {
   spaces
   case parseDouble (pack chars) of
     Nothing => fail $ "Could not parse " ++ (pack chars) ++ " as a double"
-    Just x => return x
+    Just x => pure x
 }
 
 parseBool : Parser Bool
-parseBool = ((char 't' *!> token "rue" *> return True)
-        <|> (char 'f' *!> token "alse" *> return False))
+parseBool = ((char 't' *!> token "rue" *> pure True)
+        <|> (char 'f' *!> token "alse" *> pure False))
         <?> "A boolean value (\"true\" or \"false\")"
 
 parseEnum : Parser (interpEnum d)
@@ -130,7 +130,7 @@ parseEnum {d=MkEnumDescriptor enumName values} = do {
     Nothing => fail (
       "An field in the enum " ++ enumName ++ " (no field named " ++
       (show (pack chars)) ++ ")")
-    Just i => return i
+    Just i => pure i
 }
 
 mutual
@@ -139,7 +139,7 @@ mutual
     xs <- parseFields msgName
     case messageFromFieldList {fields=fields} xs of
       Left err => fail ("A valid message (" ++ err ++ ")")
-      Right fs => return (MkMessage fs)
+      Right fs => pure (MkMessage fs)
   }
 
   parseFields : (msgName : String) -> Parser (FieldList d)
@@ -154,7 +154,7 @@ mutual
           (show (pack chars)) ++ ")")
         Just i => do {
           v <- parseField
-          return (i ** v)
+          pure (i ** v)
         }
     })
   })

--- a/Protobuf/Util.idr
+++ b/Protobuf/Util.idr
@@ -25,7 +25,7 @@ import Protobuf.Printer
 
 ||| Does an action for each element of a list.
 forEach : Monad m => (a -> m ()) -> List a -> m ()
-forEach _ Nil       = return ()
+forEach _ Nil       = pure ()
 forEach f (x :: xs) = do {
   f x
   forEach f xs

--- a/Test/Parser.idr
+++ b/Test/Parser.idr
@@ -23,20 +23,19 @@ import Protobuf.Util
 %access export
 
 protoFileContents : String
-protoFileContents = unlines [
-  "message Person {",
-  "  required string name = 0;",
-  "  required int32 id = 1;",
-  "  optional string email = 2;",
-  "  message PhoneNumber {",
-  "    required string number = 0;",
-  "    enum PhoneType {MOBILE = 0; HOME = 1; WORK = 2;}",
-  "    optional Person.PhoneNumber.PhoneType type = 1;",
-  "  }",
-  "  repeated Person.PhoneNumber phone = 3;",
-  "}",
-  ""
-]
+protoFileContents =
+  """message Person {
+  required string name = 0;
+  required int32 id = 1;
+  optional string email = 2;
+  message PhoneNumber {
+      required string number = 0;
+      enum PhoneType {MOBILE = 0; HOME = 1; WORK = 2;}
+      optional Person.PhoneNumber.PhoneType type = 1;
+    }
+    repeated Person.PhoneNumber phone = 3;
+  }
+  """
 
 expectedFileDescriptor : (List MessageDescriptor, List EnumDescriptor)
 expectedFileDescriptor = ([PhoneNumber, Person], [PhoneType])

--- a/Test/TextFormat.idr
+++ b/Test/TextFormat.idr
@@ -23,19 +23,18 @@ import Protobuf.TextFormat
 %default total
 
 johnInTextFormat : String
-johnInTextFormat = unlines [
-  "name: \"John Doe\"",
-  "id: 1234",
-  "email: \"jdoe@example.com\"",
-  "phone: {",
-  "  number: \"123-456-7890\"",
-  "  type: HOME",
-  "}",
-  "phone: {",
-  "  number: \"987-654-3210\"",
-  "}",
-  ""
-]
+johnInTextFormat =
+  """name: "John Doe"
+id: 1234
+email: "jdoe@example.com"
+phone: {
+  number: "123-456-7890"
+  type: HOME
+}
+phone: {
+  number: "987-654-3210"
+}
+"""
 
 -- Implementing Eq (InterpMessage d) is proving difficult so for testing we
 -- implement it by serializing to text format and comparing.
@@ -61,11 +60,13 @@ allTests = runTests (MkTestFixture "TextFormat" [
   MkTestCase "ParseMessageWithBadField"
     (assertEq
       (parseFromTextFormat {d=Person} "not_a_field: 1")
-      (Left "at 1:14 expected:\n  An field in the message Person (no field named \"not_a_field\")")),
+      (Left """At 1:14:
+	An field in the message Person (no field named "not_a_field")""")),
   MkTestCase "ParseMessageWithMissingRequiredField"
     (assertEq
         (parseFromTextFormat {d=Person} "id: 1234")
-        (Left "at 0:0 expected:\n  A valid message (The required field \"name\" was not set.)")),
+        (Left """At 1:9:
+	A valid message (The required field "name" was not set.)""")),
   MkTestCase "ParseMessageWithOverriddenRequiredField"
     (assertEq (parseFromTextFormat (johnInTextFormat ++ "name: \"Jane Doe\"\n")) (Right Jane)),
   MkTestCase "ParseDouble"

--- a/Test/UnitTest.idr
+++ b/Test/UnitTest.idr
@@ -28,12 +28,12 @@ failAssert err = Left err
 
 assertEq : (Eq a, Show a) => (given : a) -> (expected : a) -> Test ()
 assertEq g e = if g == e
-  then return ()
+  then pure ()
   else failAssert ("assertEq failed: got " ++ (show g) ++ ", expected " ++ (show e))
 
 assertEq' : Eq a => (given : a) -> (expected : a) -> Test ()
 assertEq' g e = if g == e
-    then return ()
+    then pure ()
     else failAssert "assertEq Failed"
 
 record TestCase where


### PR DESCRIPTION
First, some signatures:

  execParserT : Monad m => ParserT str m a -> State str -> m (Reply str a)
  runStateT : StateT stateType m a -> stateType -> m (a, stateType)
  evalState : State stateType a -> stateType -> a

Since the signature of execParserT seems to have changed from the time
when Protobuf was last working, we use runStateT instead of evalState,
and pattern-match accordingly.

While at it, modernize some `return` calls to read as `pure`. Finally,
update the tests; the changes are pretty minor, but we take the
opportunity to use a relatively new feature of the Idris language,
triple-quoted string literals.

Signed-off-by: Ramkumar Ramachandra <artagnon@gmail.com>